### PR TITLE
sum: Fix tarsum build error

### DIFF
--- a/sum/layer.go
+++ b/sum/layer.go
@@ -57,8 +57,11 @@ func SumTarLayer(tarReader io.Reader, json io.Reader, out io.Writer) (string, er
 	if out != nil {
 		writer = out
 	}
-	ts := &tarsum.TarSum{Reader: tarReader}
-	_, err := io.Copy(writer, ts)
+	ts, err := tarsum.NewTarSum(tarReader, true, tarsum.Version0)
+	if err != nil {
+		return "", err
+	}
+	_, err = io.Copy(writer, ts)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Builds of `d2r` currently fail with:

```
$ go get github.com/vbatts/docker-utils/cmd/d2r
src/github.com/vbatts/docker-utils/sum/layer.go:60: invalid pointer type *tarsum.TarSum for composite literal
```

It looks like Docker's interface might have changed in docker/docker@ec01eb653db9d5e5b9291c1670dde57e7f742874, and switching to `tarsum.NewTarSum` seems to fix the build error.
