### PR TITLE
Add a horrid Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.4
+
+# cache-fill before COPY
+# (docker/docker via git clone --depth=1 for speed)
+RUN mkdir -p /go/src/github.com/docker \
+	&& git clone --depth=1 https://github.com/docker/docker.git /go/src/github.com/docker/docker
+ENV GOPATH $GOPATH:/go/src/github.com/docker/docker/vendor
+# (also, naughty vbatts using things outside pkg/ from docker/docker)
+RUN cd /go/src/github.com/docker/docker \
+	&& bash hack/make/.go-autogen
+RUN go get -d -v github.com/Sirupsen/logrus
+
+WORKDIR /go/src/github.com/vbatts/docker-utils
+COPY . /go/src/github.com/vbatts/docker-utils
+RUN go get -d -v ./...
+RUN go install -v ./...


### PR DESCRIPTION
```console
$ time docker build --no-cache .
Sending build context to Docker daemon 217.1 kB
Sending build context to Docker daemon 
Step 0 : FROM golang:1.4
 ---> ca0f230b927e
Step 1 : RUN mkdir -p /go/src/github.com/docker 	&& git clone --depth=1 https://github.com/docker/docker.git /go/src/github.com/docker/docker
 ---> Running in a06225dab76c
Cloning into '/go/src/github.com/docker/docker'...
 ---> 69a7c2d88901
Removing intermediate container a06225dab76c
Step 2 : ENV GOPATH $GOPATH:/go/src/github.com/docker/docker/vendor
 ---> Running in a08344598c3c
 ---> 8f6456696bf6
Removing intermediate container a08344598c3c
Step 3 : RUN cd /go/src/github.com/docker/docker 	&& bash hack/make/.go-autogen
 ---> Running in e0605f80d058
 ---> 59c6258fa160
Removing intermediate container e0605f80d058
Step 4 : RUN go get -d -v github.com/Sirupsen/logrus
 ---> Running in a12da22d30f9
 ---> 343385c95e0a
Removing intermediate container a12da22d30f9
Step 5 : WORKDIR /go/src/github.com/vbatts/docker-utils
 ---> Running in 03aad49b6584
 ---> dbe9f58a28e2
Removing intermediate container 03aad49b6584
Step 6 : COPY . /go/src/github.com/vbatts/docker-utils
 ---> 366e6ebb267a
Removing intermediate container 43a2b952c681
Step 7 : RUN go get -d -v ./...
 ---> Running in 0a9f6a9ad1d6
 ---> 284012f2f536
Removing intermediate container 0a9f6a9ad1d6
Step 8 : RUN go install -v ./...
 ---> Running in 8e56be6667f9
github.com/Sirupsen/logrus
github.com/docker/docker/pkg/tarsum
github.com/docker/docker/pkg/parsers
github.com/docker/docker/pkg/version
github.com/docker/libcontainer/user
github.com/docker/docker/pkg/ulimit
github.com/docker/docker/pkg/units
github.com/docker/docker/autogen/dockerversion
github.com/docker/docker/nat
github.com/docker/docker/pkg/term
github.com/docker/docker/pkg/timeutils
github.com/docker/docker/pkg/pubsub
github.com/docker/docker/pkg/ioutils
github.com/docker/docker/pkg/promise
github.com/docker/docker/pkg/system
github.com/docker/docker/graph/tags
github.com/docker/docker/pkg/reexec
github.com/docker/docker/daemon/network
github.com/docker/docker/pkg/homedir
github.com/docker/docker/pkg/parsers/filters
github.com/docker/docker/pkg/pools
github.com/docker/docker/pkg/stringid
github.com/tchap/go-patricia/patricia
github.com/docker/docker/pkg/fileutils
github.com/docker/docker/pkg/mflag
github.com/docker/docker/cliconfig
github.com/gorilla/context
github.com/docker/docker/pkg/parsers/kernel
github.com/docker/distribution/digest
github.com/docker/docker/pkg/archive
github.com/docker/docker/pkg/requestdecorator
github.com/docker/docker/pkg/timeoutconn
github.com/docker/libtrust
github.com/gorilla/mux
github.com/docker/docker/pkg/truncindex
github.com/docker/docker/pkg/urlutil
github.com/vbatts/docker-utils/sum
github.com/vbatts/docker-utils/version
github.com/vbatts/docker-utils/cmd/d2r/fsrv
github.com/docker/docker/opts
github.com/vbatts/docker-utils/dockerfile
github.com/vbatts/docker-utils/opts
github.com/vbatts/docker-utils/cmd/dockertarsum
github.com/docker/distribution/registry/api/v2
github.com/vbatts/docker-utils/cmd/docker-save-dockerfile
github.com/docker/docker/runconfig
github.com/docker/docker/daemon/graphdriver
github.com/docker/docker/pkg/chrootarchive
github.com/docker/docker/utils
github.com/docker/libtrust/trustgraph
github.com/docker/docker/pkg/jsonmessage
github.com/docker/docker/trust
github.com/docker/docker/daemon/events
github.com/docker/docker/pkg/httputils
github.com/docker/docker/pkg/streamformatter
github.com/docker/docker/api/types
github.com/docker/docker/image
github.com/docker/docker/pkg/progressreader
github.com/docker/docker/registry
github.com/docker/docker/graph
github.com/vbatts/docker-utils/registry
github.com/vbatts/docker-utils/cmd/docker-fetch
github.com/vbatts/docker-utils/cmd/d2r
 ---> 58be0d49775e
Removing intermediate container 8e56be6667f9
Successfully built 58be0d49775e

real	0m24.216s
user	0m0.022s
sys	0m0.029s
$ docker run -it --rm 58be0d49775e d2r -v
d2r - 1.0.1-dev
```